### PR TITLE
Introduce on demand Goro implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ android:
   - build-tools-22.0.1
   - android-22
   - extra-android-m2repository
-  - sys-img-armeabi-android-10
+  - sys-img-armeabi-v7a-android-15
 
 jdk:
   - oraclejdk8
@@ -14,7 +14,7 @@ install:
   - ./gradlew clean assemble
 
 before_script:
-  - echo no | android create avd --force -n test -t android-10 --abi armeabi
+  - echo no | android create avd --force -n test -t android-15 --abi armeabi-v7a
   - emulator -avd test -no-skin -no-audio -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82

--- a/goro/src/androidTest/java/com/stanfy/enroscar/goro/OnDemandBindingGoroAndroidTest.java
+++ b/goro/src/androidTest/java/com/stanfy/enroscar/goro/OnDemandBindingGoroAndroidTest.java
@@ -1,0 +1,73 @@
+package com.stanfy.enroscar.goro;
+
+import android.annotation.TargetApi;
+import android.app.Application;
+import android.os.AsyncTask;
+import android.os.Build;
+import android.test.ApplicationTestCase;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
+public class OnDemandBindingGoroAndroidTest extends ApplicationTestCase<Application> {
+
+  private OnDemandBindingGoro goro;
+
+  public OnDemandBindingGoroAndroidTest() {
+    super(Application.class);
+  }
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+    createApplication();
+    GoroService.setDelegateExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
+    this.goro = (OnDemandBindingGoro) Goro.bindOnDemandWith(getApplication());
+  }
+
+  public void testSchedule() throws InterruptedException {
+    final CountDownLatch sync = new CountDownLatch(1);
+    Callable<String> task = new Callable<String>() {
+      @Override
+      public String call() {
+        return "done";
+      }
+    };
+    final Object[] result = new Object[1];
+    goro.schedule(task)
+        .subscribe(new FutureObserver<String>() {
+          @Override
+          public void onSuccess(final String value) {
+            result[0] = value;
+            sync.countDown();
+          }
+
+          @Override
+          public void onError(final Throwable error) {
+            result[0] = error;
+            sync.countDown();
+          }
+        });
+    assertThat(sync.await(2, TimeUnit.SECONDS)).describedAs("Operation timed out").isTrue();
+    assertThat(result).containsOnly("done");
+    assertThat(goro.delegate()).describedAs("Service must be unbound").isNull();
+  }
+
+  public void testExecutor() throws Exception {
+    final CountDownLatch sync = new CountDownLatch(1);
+    Runnable task = new Runnable() {
+      @Override
+      public void run() {
+        sync.countDown();
+      }
+    };
+    goro.getExecutor("test").execute(task);
+    assertThat(sync.await(2, TimeUnit.SECONDS)).describedAs("Operation timed out").isTrue();
+    assertThat(goro.delegate()).describedAs("Service must be unbound").isNull();
+  }
+
+}

--- a/goro/src/main/java/com/stanfy/enroscar/goro/BaseListenersHandler.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/BaseListenersHandler.java
@@ -33,14 +33,18 @@ class BaseListenersHandler {
     taskListeners.add(listener);
   }
 
-  public void removeTaskListener(final GoroListener listener) {
+  public void removeTaskListenerOrThrow(final GoroListener listener) {
+    if (!removeTaskListener(listener)) {
+      throw new GoroException("Listener " + listener + " is not registered");
+    }
+  }
+
+  public boolean removeTaskListener(final GoroListener listener) {
     if (listener == null) {
       throw new IllegalArgumentException("Listener cannot be null");
     }
     checkThread();
-    if (!taskListeners.remove(listener)) {
-      throw new GoroException("Listener " + listener + " is not registered");
-    }
+    return taskListeners.remove(listener);
   }
 
 }

--- a/goro/src/main/java/com/stanfy/enroscar/goro/BoundGoro.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/BoundGoro.java
@@ -5,22 +5,12 @@ import android.content.Context;
 import android.content.ServiceConnection;
 import android.os.IBinder;
 
-import java.util.ArrayList;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CancellationException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static com.stanfy.enroscar.goro.GoroFuture.IMMEDIATE;
-import static com.stanfy.enroscar.goro.Util.checkMainThread;
-
 /**
- * Handles tasks in multiple queues using Android service.
+ * Handles tasks in multiple queues using a worker service.
+ * Exposes methods to explicitly control binding to and unbinding from the service.
  * @see com.stanfy.enroscar.goro.GoroService
  */
-public abstract class BoundGoro extends Goro implements ServiceConnection {
+public abstract class BoundGoro extends BufferedGoroDelegate {
 
   /** Bind to {@link com.stanfy.enroscar.goro.GoroService}. */
   public abstract void bind();
@@ -39,20 +29,8 @@ public abstract class BoundGoro extends Goro implements ServiceConnection {
     /** Instance of the context used to bind to GoroService. */
     private final Context context;
 
-    /** Temporal array of listeners that must be added after getting service connection. */
-    private final BaseListenersHandler scheduledListeners = new BaseListenersHandler(2);
-
-    /** Postponed data. */
-    private final ArrayList<Postponed> postponed = new ArrayList<>(7);
-
-    /** Protects service instance. */
-    private final Object lock = new Object();
-
     /** Disconnection handler. */
     private final OnUnexpectedDisconnection disconnectionHandler;
-
-    /** Instance from service. */
-    private Goro service;
 
     BoundGoroImpl(final Context context, final OnUnexpectedDisconnection disconnectionHandler) {
       this.context = context;
@@ -66,338 +44,32 @@ public abstract class BoundGoro extends Goro implements ServiceConnection {
 
     @Override
     public void unbind() {
-      synchronized (lock) {
-        service = null;
+      if (updateDelegate(null)) {
         GoroService.unbind(context, this);
       }
     }
 
     @Override
     public void onServiceConnected(final ComponentName name, final IBinder binder) {
-      synchronized (lock) {
-        if (service != null) {
-          throw new GoroException("Already bound and got onServiceConnected from " + name);
-        }
-        service = Goro.from(binder);
-
-        // delegate listeners
-        if (!scheduledListeners.taskListeners.isEmpty()) {
-          for (GoroListener listener : scheduledListeners.taskListeners) {
-            service.addTaskListener(listener);
-          }
-          scheduledListeners.taskListeners.clear();
-        }
-
-        // delegate tasks
-        if (!postponed.isEmpty()) {
-          for (Postponed p : postponed) {
-            p.act(service);
-          }
-          postponed.clear();
-        }
-      }
-    }
-
-    Goro getServiceObject() {
-      return service;
-    }
-
-    boolean cancelPostponed(final Postponed p) {
-      synchronized (lock) {
-        return postponed.remove(p);
-      }
+      updateDelegate(Goro.from(binder));
     }
 
     @Override
     public void onServiceDisconnected(final ComponentName name) {
-      synchronized (lock) {
-        if (service != null) {
-          /*
-            It's the case when service was stopped by a system server.
-            It can happen when user presses a stop button in application settings (in running apps section).
-            Sometimes this happens on application update.
-           */
-          service = null;
-          if (disconnectionHandler == null) {
-            bind();
-          } else {
-            disconnectionHandler.onServiceDisconnected(this);
-          }
-        }
-      }
-    }
-
-    @Override
-    public void addTaskListener(final GoroListener listener) {
-      // main thread => no sync
-      Goro service = this.service;
-      if (service != null) {
-        service.addTaskListener(listener);
-      } else {
-        scheduledListeners.addTaskListener(listener);
-      }
-    }
-
-    @Override
-    public void removeTaskListener(final GoroListener listener) {
-      // main thread => no sync
-      Goro service = this.service;
-      if (service != null) {
-        service.removeTaskListener(listener);
-      } else {
-        scheduledListeners.removeTaskListener(listener);
-      }
-    }
-
-    @Override
-    public <T> ObservableFuture<T> schedule(final Callable<T> task) {
-      return schedule(DEFAULT_QUEUE, task);
-    }
-
-    @Override
-    public <T> ObservableFuture<T> schedule(String queueName, Callable<T> task) {
-      synchronized (lock) {
-        if (service != null) {
-          return service.schedule(queueName, task);
+      if (updateDelegate(null)) {
+        /*
+          It's the case when service was stopped by a system server.
+          It can happen when user presses a stop button in application settings (in running apps section).
+          Sometimes this happens on application update.
+         */
+        if (disconnectionHandler == null) {
+          bind();
         } else {
-          BoundFuture<T> future = new BoundFuture<>(queueName, task);
-          postponed.add(future);
-          return future;
+          disconnectionHandler.onServiceDisconnected(this);
         }
       }
     }
 
-    @Override
-    public Executor getExecutor(final String queueName) {
-      synchronized (lock) {
-        if (service != null) {
-          return service.getExecutor(queueName);
-        }
-        return new PostponeExecutor(queueName);
-      }
-    }
-
-    @Override
-    protected void removeTasksInQueue(final String queueName) {
-      synchronized (lock) {
-        if (service != null) {
-          service.clear(queueName);
-        }
-        postponed.add(new ClearAction(queueName));
-      }
-    }
-
-    /** Some postponed action. */
-    private interface Postponed {
-      void act(Goro goro);
-    }
-
-    /** Recorded task info. */
-    private static final class RunnableData implements Postponed {
-      /** Queue name. */
-      final String queue;
-      /** Runnable action. */
-      final Runnable command;
-
-      RunnableData(final String queue, final Runnable command) {
-        this.queue = queue;
-        this.command = command;
-      }
-
-      @Override
-      public void act(final Goro goro) {
-        goro.getExecutor(queue).execute(command);
-      }
-    }
-
-    /** Postponed clear call. */
-    private static final class ClearAction implements Postponed {
-      /** Queue name. */
-      private final String queueName;
-
-      ClearAction(final String queueName) {
-        this.queueName = queueName;
-      }
-
-      @Override
-      public void act(final Goro goro) {
-        goro.clear(queueName);
-      }
-    }
-
-    /** Executor implementation. */
-    private final class PostponeExecutor implements Executor {
-
-      /** Queue name. */
-      private final String queueName;
-
-      private PostponeExecutor(final String queueName) {
-        this.queueName = queueName;
-      }
-
-      @Override
-      public void execute(@SuppressWarnings("NullableProblems") final Runnable command) {
-        synchronized (lock) {
-          if (service != null) {
-            service.getExecutor(queueName).execute(command);
-          } else {
-            postponed.add(new RunnableData(queueName, command));
-          }
-        }
-      }
-    }
-
-    /** Postponed scheduled future. */
-    private final class BoundFuture<T> implements ObservableFuture<T>, Postponed {
-
-      /** Queue name. */
-      final String queue;
-      /** Task instance. */
-      final Callable<T> task;
-
-      /** Attached Goro future. */
-      private GoroFuture<T> goroFuture;
-
-      /** Cancel flag. */
-      private boolean canceled;
-
-      /** Observers list. */
-      private PendingObserversList pendingObservers;
-
-      private BoundFuture(final String queue, final Callable<T> task) {
-        this.queue = queue;
-        this.task = task;
-      }
-
-      @Override
-      public synchronized void act(final Goro goro) {
-        goroFuture = (GoroFuture<T>) goro.schedule(queue, task);
-        if (pendingObservers != null) {
-          pendingObservers.execute();
-          pendingObservers = null;
-        }
-        notifyAll();
-      }
-
-      @Override
-      public synchronized boolean cancel(boolean mayInterruptIfRunning) {
-        if (goroFuture != null) {
-          return goroFuture.cancel(mayInterruptIfRunning);
-        }
-        if (!canceled) {
-          cancelPostponed(this);
-          pendingObservers = null;
-          canceled = true;
-        }
-        notifyAll();
-        return true;
-      }
-
-      @Override
-      public synchronized boolean isCancelled() {
-        if (goroFuture != null) {
-          return goroFuture.isCancelled();
-        }
-        return canceled;
-      }
-
-      @Override
-      public synchronized boolean isDone() {
-        return canceled || goroFuture != null && goroFuture.isDone();
-      }
-
-      @Override
-      public synchronized T get() throws InterruptedException, ExecutionException {
-        // delegate
-        if (goroFuture != null) {
-          return goroFuture.get();
-        }
-        if (checkMainThread()) {
-          throw new GoroException("Blocking main thread here will lead to a deadlock");
-        }
-
-        if (canceled) {
-          throw new CancellationException("Task was canceled");
-        }
-
-        // wait for act() or cancel()
-        wait();
-
-        // either we got a delegate
-        if (goroFuture != null) {
-          return goroFuture.get();
-        }
-        // or we are canceled
-        if (canceled) {
-          throw new CancellationException("Task was canceled");
-        }
-
-        // wtf?
-        throw new IllegalStateException("get() is unblocked but there is neither result"
-            + " nor cancellation");
-      }
-
-      @Override
-      public synchronized T get(final long timeout, @SuppressWarnings("NullableProblems") final TimeUnit unit)
-          throws InterruptedException, ExecutionException, TimeoutException {
-        // delegate
-        if (goroFuture != null) {
-          return goroFuture.get(timeout, unit);
-        }
-        if (checkMainThread()) {
-          throw new GoroException("Blocking main thread here will lead to a deadlock");
-        }
-
-        if (canceled) {
-          throw new CancellationException("Task was canceled");
-        }
-
-        // wait for act() or cancel()
-        wait(unit.toMillis(timeout));
-
-        // either we got a delegate
-        if (goroFuture != null) {
-          return goroFuture.get();
-        }
-        // or we are canceled
-        if (canceled) {
-          throw new CancellationException("Task was canceled");
-        }
-
-        // otherwise it's a timeout
-        throw new TimeoutException();
-      }
-
-      @Override
-      public synchronized void subscribe(final Executor executor, final FutureObserver<T> observer) {
-        if (goroFuture != null) {
-          goroFuture.subscribe(executor, observer);
-          return;
-        }
-        if (canceled) {
-          return;
-        }
-
-        if (pendingObservers == null) {
-          pendingObservers = new PendingObserversList();
-        }
-        pendingObservers.add(new GoroFuture.ObserverRunnable<>(observer, null), executor);
-      }
-
-      @Override
-      public void subscribe(final FutureObserver<T> observer) {
-        subscribe(IMMEDIATE, observer);
-      }
-
-      /** List of pending observers. */
-      private final class PendingObserversList extends ExecutionObserversList {
-        @Override
-        protected void executeObserver(final Executor executor, final Runnable what) {
-          GoroFuture.ObserverRunnable runnable = (GoroFuture.ObserverRunnable) what;
-          runnable.future = goroFuture;
-          goroFuture.observers.add(what, executor);
-        }
-      }
-    }
   }
+
 }

--- a/goro/src/main/java/com/stanfy/enroscar/goro/BufferedGoroDelegate.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/BufferedGoroDelegate.java
@@ -1,0 +1,357 @@
+package com.stanfy.enroscar.goro;
+
+import java.util.ArrayList;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static com.stanfy.enroscar.goro.GoroFuture.IMMEDIATE;
+import static com.stanfy.enroscar.goro.Util.checkMainThread;
+
+/**
+ * Either delegates a call to a wrapped Goro or buffers invocation data.
+ */
+abstract class BufferedGoroDelegate extends Goro {
+
+  /** Delegate instance. */
+  private Goro delegate;
+
+  /** Temporal array of listeners that must be added after getting service connection. */
+  private final BaseListenersHandler scheduledListeners = new BaseListenersHandler(2);
+
+  /** Postponed data. */
+  private final ArrayList<Postponed> postponed = new ArrayList<>(7);
+
+  /** Protects service instance. */
+  private final Object lock = new Object();
+
+  protected boolean updateDelegate(final Goro delegate) {
+    synchronized (lock) {
+      if (this.delegate != delegate) {
+        if (this.delegate != null && delegate != null) {
+          throw new GoroException("Got a new delegate " + delegate
+              + " while being attached to another " + this.delegate);
+        }
+        this.delegate = delegate;
+
+        if (this.delegate != null) {
+          // Delegate listeners.
+          if (!scheduledListeners.taskListeners.isEmpty()) {
+            for (GoroListener listener : scheduledListeners.taskListeners) {
+              delegate.addTaskListener(listener);
+            }
+            scheduledListeners.taskListeners.clear();
+          }
+
+          // Delegate tasks.
+          if (!postponed.isEmpty()) {
+            for (Postponed p : postponed) {
+              p.act(delegate);
+            }
+            postponed.clear();
+          }
+        }
+
+        return true;
+      }
+      return false;
+    }
+  }
+
+  /** Use in tests only. */
+  final Goro delegate() {
+    return delegate;
+  }
+
+  @Override
+  public void addTaskListener(final GoroListener listener) {
+    // Main thread => no sync.
+    Goro goro = delegate;
+    if (goro != null) {
+      goro.addTaskListener(listener);
+    } else {
+      scheduledListeners.addTaskListener(listener);
+    }
+  }
+
+  @Override
+  public void removeTaskListener(final GoroListener listener) {
+    // Main thread => no sync.
+    Goro goro = delegate;
+    if (goro != null) {
+      goro.removeTaskListener(listener);
+    } else {
+      if (!scheduledListeners.removeTaskListener(listener)) {
+        // Delegate later.
+        postponed.add(new Postponed() {
+          @Override
+          public void act(final Goro goro) {
+            goro.removeTaskListener(listener);
+          }
+        });
+      }
+    }
+  }
+
+  @Override
+  public final <T> ObservableFuture<T> schedule(Callable<T> task) {
+    return schedule(DEFAULT_QUEUE, task);
+  }
+
+  @Override
+  public <T> ObservableFuture<T> schedule(String queueName, Callable<T> task) {
+    synchronized (lock) {
+      if (delegate != null) {
+        return delegate.schedule(queueName, task);
+      } else {
+        BoundFuture<T> future = new BoundFuture<>(queueName, task);
+        postponed.add(future);
+        return future;
+      }
+    }
+  }
+
+  @Override
+  public Executor getExecutor(final String queueName) {
+    synchronized (lock) {
+      if (delegate != null) {
+        return delegate.getExecutor(queueName);
+      }
+      return new PostponeExecutor(queueName);
+    }
+  }
+
+  @Override
+  protected void removeTasksInQueue(final String queueName) {
+    synchronized (lock) {
+      if (delegate != null) {
+        delegate.clear(queueName);
+      } else {
+        postponed.add(new ClearAction(queueName));
+      }
+    }
+  }
+
+  boolean cancelPostponed(final Postponed p) {
+    synchronized (lock) {
+      return postponed.remove(p);
+    }
+  }
+
+  /** Some postponed action. */
+  private interface Postponed {
+    void act(Goro goro);
+  }
+
+  /** Postponed clear call. */
+  private static final class ClearAction implements Postponed {
+    /** Queue name. */
+    private final String queueName;
+
+    ClearAction(final String queueName) {
+      this.queueName = queueName;
+    }
+
+    @Override
+    public void act(final Goro goro) {
+      goro.clear(queueName);
+    }
+  }
+
+  /** Postponed action passed to an executor. */
+  private static final class ExecutorAction implements Postponed {
+    /** Queue name. */
+    final String queue;
+    /** Runnable action. */
+    final Runnable command;
+
+    ExecutorAction(final String queue, final Runnable command) {
+      this.queue = queue;
+      this.command = command;
+    }
+
+    @Override
+    public void act(final Goro goro) {
+      goro.getExecutor(queue).execute(command);
+    }
+  }
+
+  /** Executor implementation. */
+  private final class PostponeExecutor implements Executor {
+
+    /** Queue name. */
+    private final String queueName;
+
+    private PostponeExecutor(final String queueName) {
+      this.queueName = queueName;
+    }
+
+    @Override
+    public void execute(@SuppressWarnings("NullableProblems") final Runnable command) {
+      synchronized (lock) {
+        if (delegate != null) {
+          delegate.getExecutor(queueName).execute(command);
+        } else {
+          postponed.add(new ExecutorAction(queueName, command));
+        }
+      }
+    }
+  }
+
+  /** Postponed scheduled future. */
+  private final class BoundFuture<T> implements ObservableFuture<T>, Postponed {
+
+    /** Queue name. */
+    final String queue;
+    /** Task instance. */
+    final Callable<T> task;
+
+    /** Attached Goro future. */
+    private GoroFuture<T> goroFuture;
+
+    /** Cancel flag. */
+    private boolean canceled;
+
+    /** Observers list. */
+    private PendingObserversList pendingObservers;
+
+    private BoundFuture(final String queue, final Callable<T> task) {
+      this.queue = queue;
+      this.task = task;
+    }
+
+    @Override
+    public synchronized void act(final Goro goro) {
+      goroFuture = (GoroFuture<T>) goro.schedule(queue, task);
+      if (pendingObservers != null) {
+        pendingObservers.execute();
+        pendingObservers = null;
+      }
+      notifyAll();
+    }
+
+    @Override
+    public synchronized boolean cancel(boolean mayInterruptIfRunning) {
+      if (goroFuture != null) {
+        return goroFuture.cancel(mayInterruptIfRunning);
+      }
+      if (!canceled) {
+        cancelPostponed(this);
+        pendingObservers = null;
+        canceled = true;
+      }
+      notifyAll();
+      return true;
+    }
+
+    @Override
+    public synchronized boolean isCancelled() {
+      if (goroFuture != null) {
+        return goroFuture.isCancelled();
+      }
+      return canceled;
+    }
+
+    @Override
+    public synchronized boolean isDone() {
+      return canceled || goroFuture != null && goroFuture.isDone();
+    }
+
+    @Override
+    public synchronized T get() throws InterruptedException, ExecutionException {
+      // delegate
+      if (goroFuture != null) {
+        return goroFuture.get();
+      }
+      if (checkMainThread()) {
+        throw new GoroException("Blocking main thread here will lead to a deadlock");
+      }
+
+      if (canceled) {
+        throw new CancellationException("Task was canceled");
+      }
+
+      // wait for act() or cancel()
+      wait();
+
+      // either we got a delegate
+      if (goroFuture != null) {
+        return goroFuture.get();
+      }
+      // or we are canceled
+      if (canceled) {
+        throw new CancellationException("Task was canceled");
+      }
+
+      // wtf?
+      throw new IllegalStateException("get() is unblocked but there is neither result"
+          + " nor cancellation");
+    }
+
+    @Override
+    public synchronized T get(final long timeout, @SuppressWarnings("NullableProblems") final TimeUnit unit)
+        throws InterruptedException, ExecutionException, TimeoutException {
+      // delegate
+      if (goroFuture != null) {
+        return goroFuture.get(timeout, unit);
+      }
+      if (checkMainThread()) {
+        throw new GoroException("Blocking main thread here will lead to a deadlock");
+      }
+
+      if (canceled) {
+        throw new CancellationException("Task was canceled");
+      }
+
+      // wait for act() or cancel()
+      wait(unit.toMillis(timeout));
+
+      // either we got a delegate
+      if (goroFuture != null) {
+        return goroFuture.get();
+      }
+      // or we are canceled
+      if (canceled) {
+        throw new CancellationException("Task was canceled");
+      }
+
+      // otherwise it's a timeout
+      throw new TimeoutException();
+    }
+
+    @Override
+    public synchronized void subscribe(final Executor executor, final FutureObserver<T> observer) {
+      if (goroFuture != null) {
+        goroFuture.subscribe(executor, observer);
+        return;
+      }
+      if (canceled) {
+        return;
+      }
+
+      if (pendingObservers == null) {
+        pendingObservers = new PendingObserversList();
+      }
+      pendingObservers.add(new GoroFuture.ObserverRunnable<>(observer, null), executor);
+    }
+
+    @Override
+    public void subscribe(final FutureObserver<T> observer) {
+      subscribe(IMMEDIATE, observer);
+    }
+
+    /** List of pending observers. */
+    private final class PendingObserversList extends ExecutionObserversList {
+      @Override
+      protected void executeObserver(final Executor executor, final Runnable what) {
+        GoroFuture.ObserverRunnable runnable = (GoroFuture.ObserverRunnable) what;
+        runnable.future = goroFuture;
+        goroFuture.observers.add(what, executor);
+      }
+    }
+  }
+
+}

--- a/goro/src/main/java/com/stanfy/enroscar/goro/Goro.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/Goro.java
@@ -63,15 +63,18 @@ public abstract class Goro {
    *   </pre>
    * </p>
    * @param context context that will bind to the service
-   * @return Goro implementation that binds to {@link com.stanfy.enroscar.goro.GoroService}.
+   * @return Goro implementation that binds to {@link GoroService}.
    * @see #bindWith(Context, BoundGoro.OnUnexpectedDisconnection)
    */
   public static BoundGoro bindAndAutoReconnectWith(final Context context) {
+    if (context == null) {
+      throw new IllegalArgumentException("Context cannot be null");
+    }
     return new BoundGoroImpl(context, null);
   }
 
   /**
-   * Creates a Goro implementation that binds to {@link com.stanfy.enroscar.goro.GoroService}
+   * Creates a Goro implementation that binds to {@link GoroService}
    * in order to run scheduled tasks in service context.
    * {@code BoundGoro} exposes {@code bind()} and {@code unbind()} methods that you can use to connect to
    * and disconnect from the worker service in other component lifecycle callbacks
@@ -84,13 +87,30 @@ public abstract class Goro {
    * </p>
    * @param context context that will bind to the service
    * @param handler callback to invoke if worker service is unexpectedly stopped by the system server
-   * @return Goro implementation that binds to {@link com.stanfy.enroscar.goro.GoroService}.
+   * @return Goro implementation that binds to {@link GoroService}.
    */
   public static BoundGoro bindWith(final Context context, final BoundGoro.OnUnexpectedDisconnection handler) {
+    if (context == null) {
+      throw new IllegalArgumentException("Context cannot be null");
+    }
     if (handler == null) {
       throw new IllegalArgumentException("Disconnection handler cannot be null");
     }
     return new BoundGoroImpl(context, handler);
+  }
+
+  /**
+   * Creates a Goro implementation that binds to a worker service to schedule tasks.
+   * This implementation binds to the backing service when one of {@code Goro} methods is invoked,
+   * then delegates all the tasks to the service and unbinds asap.
+   * @param context context that will bind to the service
+   * @return Goro implementation that binds to {@link GoroService}
+   */
+  public static Goro bindOnDemandWith(final Context context) {
+    if (context == null) {
+      throw new IllegalArgumentException("Context cannot be null");
+    }
+    return new OnDemandBindingGoro(context);
   }
 
   /**
@@ -168,7 +188,7 @@ public abstract class Goro {
 
     @Override
     public void removeTaskListener(final GoroListener listener) {
-      listenersHandler.removeTaskListener(listener);
+      listenersHandler.removeTaskListenerOrThrow(listener);
     }
 
     @Override

--- a/goro/src/main/java/com/stanfy/enroscar/goro/GoroFuture.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/GoroFuture.java
@@ -12,9 +12,6 @@ import java.util.concurrent.FutureTask;
 /**
  * Future implementation.
  */
-/*
-  TODO: Rx support?
- */
 final class GoroFuture<T> extends FutureTask<T> implements ObservableFuture<T> {
 
   /** Immediate executor. */

--- a/goro/src/main/java/com/stanfy/enroscar/goro/OnDemandBindingGoro.java
+++ b/goro/src/main/java/com/stanfy/enroscar/goro/OnDemandBindingGoro.java
@@ -1,0 +1,81 @@
+package com.stanfy.enroscar.goro;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.ServiceConnection;
+import android.os.IBinder;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+
+/**
+ * Implementation of {@link Goro} that binds to a {@link GoroService}
+ * when a new job should be scheduled, passes the job to the service and unbinds asap.
+ */
+class OnDemandBindingGoro extends BufferedGoroDelegate implements ServiceConnection {
+
+  private final Context context;
+  private boolean bindRequested;
+
+  OnDemandBindingGoro(final Context context) {
+    this.context = context;
+  }
+
+  private synchronized void bindIfRequired() {
+    if (!bindRequested) {
+      bindRequested = true;
+      GoroService.bind(context, this);
+    }
+  }
+
+  private synchronized void unbindIfRequired() {
+    if (bindRequested && updateDelegate(null)) {
+      bindRequested = false;
+      GoroService.unbind(context, this);
+    }
+  }
+
+  @Override
+  public final void addTaskListener(final GoroListener listener) {
+    super.addTaskListener(listener);
+    bindIfRequired();
+  }
+
+  @Override
+  public final void removeTaskListener(final GoroListener listener) {
+    super.removeTaskListener(listener);
+    bindIfRequired();
+  }
+
+  @Override
+  public final <T> ObservableFuture<T> schedule(final String queueName, final Callable<T> task) {
+    ObservableFuture<T> result = super.schedule(queueName, task);
+    bindIfRequired();
+    return result;
+  }
+
+  @Override
+  public final Executor getExecutor(final String queueName) {
+    Executor executor = super.getExecutor(queueName);
+    bindIfRequired();
+    return executor;
+  }
+
+  @Override
+  protected final void removeTasksInQueue(final String queueName) {
+    super.removeTasksInQueue(queueName);
+    bindIfRequired();
+  }
+
+  @Override
+  public void onServiceConnected(final ComponentName name, final IBinder binder) {
+    updateDelegate(Goro.from(binder));
+    unbindIfRequired();
+  }
+
+  @Override
+  public void onServiceDisconnected(final ComponentName name) {
+    unbindIfRequired();
+  }
+
+}

--- a/goro/src/test/java/com/stanfy/enroscar/goro/BaseBindingGoroTest.java
+++ b/goro/src/test/java/com/stanfy/enroscar/goro/BaseBindingGoroTest.java
@@ -1,0 +1,228 @@
+package com.stanfy.enroscar.goro;
+
+import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Build;
+import android.os.IBinder;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowActivity;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.android.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = Build.VERSION_CODES.LOLLIPOP)
+public abstract class BaseBindingGoroTest {
+
+  /** Mock service instance of Goro. */
+  Goro serviceInstance;
+
+  Activity context;
+  ShadowActivity shadowContext;
+
+  IBinder binder;
+  ComponentName serviceCompName;
+  TestingQueues testingQueues;
+
+  @Before
+  public void init() {
+    context = Robolectric.setupActivity(Activity.class);
+    shadowContext = Shadows.shadowOf(context);
+
+    testingQueues = new TestingQueues();
+    serviceInstance = spy(new Goro.GoroImpl(testingQueues));
+
+    serviceCompName = new ComponentName(context, GoroService.class);
+    GoroService service = new GoroService();
+    binder = new GoroService.GoroBinderImpl(serviceInstance, service.new GoroTasksListener());
+    shadowContext.getShadowApplication()
+        .setComponentNameAndServiceForBindService(
+            serviceCompName,
+            binder
+        );
+    reset(serviceInstance);
+  }
+
+  protected abstract ServiceConnection serviceConnection();
+  protected abstract Goro goro();
+
+  protected void doBinding() { }
+
+  @SuppressWarnings("unchecked")
+  protected final Callable<String> okTask() throws Exception {
+    Callable<String> task = mock(Callable.class);
+    doReturn("ok").when(task).call();
+    return task;
+  }
+
+  protected final void assertBinding() {
+    Intent startedService = shadowContext.getNextStartedService();
+    assertThat(startedService).isNotNull();
+    assertThat(startedService).hasComponent(context, GoroService.class);
+    Intent boundService = shadowContext.getNextStartedService();
+    assertThat(boundService).isNotNull();
+    assertThat(boundService).hasComponent(context, GoroService.class);
+
+    verify(serviceConnection()).onServiceConnected(serviceCompName, binder);
+  }
+
+  @Test
+  public void addListenerShouldRecord() {
+    GoroListener listener = mock(GoroListener.class);
+    goro().addTaskListener(listener);
+    doBinding();
+    assertBinding();
+    verify(serviceInstance).addTaskListener(listener);
+  }
+
+  @Test
+  public void scheduleShouldRecordDefaultQueue() {
+    Callable<?> task = mock(Callable.class);
+    goro().schedule(task);
+    doBinding();
+    assertBinding();
+    verify(serviceInstance).schedule(Goro.DEFAULT_QUEUE, task);
+  }
+
+  @Test
+  public void scheduleShouldRequestQueueName() {
+    Callable<?> task = mock(Callable.class);
+    goro().schedule("1", task);
+    doBinding();
+    assertBinding();
+    verify(serviceInstance).schedule("1", task);
+  }
+
+  @Test
+  public void scheduleShouldReturnFuture() {
+    Future<?> future = goro().schedule(mock(Callable.class));
+    assertThat(future).isNotNull();
+  }
+
+  @Test
+  public void afterBindingAddRemoveListenerShouldBeDelegated() {
+    doBinding();
+    GoroListener listener = mock(GoroListener.class);
+    goro().addTaskListener(listener);
+    goro().removeTaskListener(listener);
+    InOrder order = inOrder(serviceInstance);
+    order.verify(serviceInstance).addTaskListener(listener);
+    order.verify(serviceInstance).removeTaskListener(listener);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void observersSuccess() throws Exception {
+    Callable<String> task = okTask();
+    FutureObserver<String> observer = mock(FutureObserver.class);
+    goro().schedule(task).subscribe(observer);
+
+    doBinding();
+    verify(serviceInstance).schedule(Goro.DEFAULT_QUEUE, task);
+    testingQueues.executeAll();
+    verify(observer).onSuccess("ok");
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void observersError() throws Exception {
+    Callable<String> task = mock(Callable.class);
+    Exception e = new Exception();
+    doThrow(e).when(task).call();
+    FutureObserver<String> observer = mock(FutureObserver.class);
+    goro().schedule(task).subscribe(observer);
+
+    doBinding();
+    testingQueues.executeAll();
+    verify(observer).onError(e);
+  }
+
+  @Test
+  public void getOnFuture() throws Exception {
+    final Future<String> f = goro().schedule(okTask());
+    final String[] result = new String[1];
+    final Exception[] error = new Exception[1];
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        try {
+          result[0] = f.get();
+        } catch (Exception e) {
+          error[0] = e;
+        }
+      }
+    };
+    t.start();
+    assertThat(result).containsNull();
+    doBinding();
+    testingQueues.executeAll();
+    t.join(1000);
+    if (error[0] != null) {
+      throw new AssertionError(error[0]);
+    }
+    assertThat(result).containsOnly("ok");
+  }
+
+  @Test
+  public void getOnFutureWithTimeout() throws Exception {
+    final Future<String> f = goro().schedule(okTask());
+    final String[] result = new String[1];
+    final Exception[] error = new Exception[1];
+    Thread t = new Thread() {
+      @Override
+      public void run() {
+        try {
+          result[0] = f.get(3, TimeUnit.SECONDS);
+        } catch (Exception e) {
+          error[0] = e;
+        }
+      }
+    };
+    t.start();
+    assertThat(result).containsNull();
+    doBinding();
+    testingQueues.executeAll();
+    t.join(1000);
+    if (error[0] != null) {
+      throw new AssertionError(error[0]);
+    }
+    assertThat(result).containsOnly("ok");
+  }
+
+  @Test
+  public void clearShouldDelegate() {
+    doBinding();
+    goro().clear("clearedQueue");
+    verify(serviceInstance).clear("clearedQueue");
+  }
+
+  @Test
+  public void clearShouldBeAppliedAfterBinding() {
+    Callable<?> task1 = mock(Callable.class);
+    goro().schedule("clearedQueue", task1);
+    goro().clear("clearedQueue");
+    Callable<?> task2 = mock(Callable.class);
+    goro().schedule("clearedQueue", task2);
+    doBinding();
+    InOrder order = inOrder(serviceInstance);
+    order.verify(serviceInstance).schedule("clearedQueue", task1);
+    order.verify(serviceInstance).clear("clearedQueue");
+    order.verify(serviceInstance).schedule("clearedQueue", task2);
+  }
+
+}

--- a/goro/src/test/java/com/stanfy/enroscar/goro/OnDemandBindingGoroTest.java
+++ b/goro/src/test/java/com/stanfy/enroscar/goro/OnDemandBindingGoroTest.java
@@ -1,0 +1,43 @@
+package com.stanfy.enroscar.goro;
+
+import android.content.ServiceConnection;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for OnDemandBindingGoro.
+ */
+public class OnDemandBindingGoroTest extends BaseBindingGoroTest {
+
+  private OnDemandBindingGoro goro;
+
+  @Before
+  public void init() {
+    super.init();
+    goro = spy((OnDemandBindingGoro) Goro.bindOnDemandWith(context));
+  }
+
+  @Override
+  protected ServiceConnection serviceConnection() {
+    return goro;
+  }
+
+  @Override
+  protected Goro goro() {
+    return goro;
+  }
+
+  @Test
+  public void scheduleShouldBeDelegated() throws Exception {
+    Callable<?> task = mock(Callable.class);
+    goro.schedule("2", task);
+    testingQueues.executeAll();
+    verify(task).call();
+  }
+
+}


### PR DESCRIPTION
The implementation tries to bind to the worker service when one of Goro methods is invoked.
Then it passes all the tasks to Goro instance behind the service and unbinds.

Closes #4.